### PR TITLE
Add eval support to cli and repl

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -23,21 +23,14 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - name: Cargo Build 
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --workspace
+          components: clippy, rustfmt
+      - name: Cargo Build
+        run: cargo build --verbose --workspace
       - name: Cargo Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --workspace
+        run: cargo test --verbose --workspace
       # Cache the `cargo build` so future jobs can reuse build
       - name: Cache cargo build
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,10 @@ name: Code Coverage
 
 on: [push, pull_request]
 
+env:
+  RUST_TEST_TIME_UNIT: 150,5000
+  RUST_TEST_TIME_INTEGRATION: 150,5000
+
 jobs:
   build:
     name: Build and Test
@@ -11,25 +15,23 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'partiql/partiql-rust-cli'
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
+          # Coverage requires the nightly toolchain because it uses the presently unstable `-Z profile` feature
+          # See: https://github.com/rust-lang/rust/issues/42524
+          # See also: https://github.com/actions-rs/grcov#usage
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2022-08-11
-          override: true
+          toolchain: nightly-2023-03-09
       - name: Cargo Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --workspace --all-features --no-fail-fast
+        run: cargo test --verbose --workspace
         env:
           CARGO_INCREMENTAL: '0'
           # https://github.com/marketplace/actions/rust-grcov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "partiql-cli"
 authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL CLI"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+homepage = "https://github.com/partiql/partiql-rust-cli"
+repository = "https://github.com/partiql/partiql-rust-cli"
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "cli"]
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.2.0"
+version = "0.3.0"
 
 # Example of customizing binaries in Cargo.toml.
 [[bin]]
@@ -26,10 +26,13 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-partiql-parser = { features=["serde"], version = "0.2.*" }
-partiql-source-map = "0.2.*"
-partiql-ast = "0.2.*"
-
+partiql-parser = { features=["serde"], version = "0.3.*" }
+partiql-source-map = "0.3.*"
+partiql-ast = "0.3.*"
+partiql-logical-planner = "0.3.*"
+partiql-logical = "0.3.*"
+partiql-value = "0.3.*"
+partiql-eval = "0.3.*"
 
 rustyline = "10.*"
 syntect = "5.*"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PartiQL Rust CLI
 PoC for a CLI & REPL. It should be considered experimental, subject to change, etc.
 
-In its current state, it largely exists to test parser interface & types from the perspective of an external application.
+In its current state, it largely exists to test parser and evaluation interfaces & types from the perspective of an 
+external application.
 Probably the mietter::Diagnostic stuff should be refactored and moved to the main parser crate.
 
 ## CLI Commands
@@ -16,36 +17,38 @@ Probably the mietter::Diagnostic stuff should be refactored and moved to the mai
     - **`png`** : print to stdout a [Graphviz][Graphviz] rendered png bitmap
     - **`display`** : display a [Graphviz][Graphviz] rendered png bitmap directly in supported terminals
   - **`query`** : the PartiQL query text
+- **`eval -E<environment file> "<query>"`** : evaluate the query with the optional global environment
+  - **`<environment file>`** : supports PartiQL values (as `.env`) and Ion text files (as `.ion`). See [sample-env](./sample-env) for some examples.
+  - **`query`** : the PartiQL query text
 
 ## REPL
 
-The REPL currently assumes most of the input line is a PartiQL query, which it will attempt to parse.
+The REPL currently assumes most of the input line is a PartiQL query, which it will attempt to parse and evaluate.
 - For an invalid query, errors are pretty printed to the output.
 - For a valid query,
-  - with no prefix, `Parse OK!` is printed to the output
+  - with no prefix, the evaluation result is pretty printed to the REPL shell
   - if prefixed by `\ast`, a rendered AST tree image is printed to the output ([see Visualization](##Visualizations))
 
 Features:
 - Syntax highlighting of query input
 - User-friendly error reporting
-- Readling/editing
+- Reading/editing
 - `CTRL-D`/`CTRL-C` to quit.
 
 # Visualizations
-Currently, compiling `partiql-cli` with `visualize` feature fails see [#1](https://github.com/partiql/partiql-rust-cli/issues/1)
-
 In order to use any of the [Graphviz][Graphviz]-based visualizations, you will need the graphviz libraries
 installed on your machine (e.g. `brew install graphviz` or similar).
 
 # TODO
 
-See [REPL-tagged issues](https://github.com/partiql/partiql-lang-rust/issues?q=is%3Aissue+is%3Aopen+%5BREPL%5D)
+See [REPL-tagged issues](https://github.com/partiql/partiql-rust-cli/issues?q=is%3Aissue+is%3Aopen+%5BREPL%5D)
 
 - Use central location for syntax files rather than embedded in this crate
 - Better interaction model
   - commands
   - more robust editing
   - etc.
+- Syntax highlighting for REPL output value
 
 
 [Graphviz]: https://graphviz.org/

--- a/sample-env/globals.env
+++ b/sample-env/globals.env
@@ -1,0 +1,12 @@
+{
+  'animals':[
+    {'name': 'Kumo', 'type': 'dog'},
+    {'name': 'Mochi', 'type': 'dog'},
+    {'name': 'Lilikoi', 'type': 'unicorn'}
+  ],
+  'types':[
+    {'id': 'dog', 'is_magic': false},
+    {'id': 'cat', 'is_magic': false},
+    {'id': 'unicorn', 'is_magic': true}
+  ]
+}

--- a/sample-env/globals.ion
+++ b/sample-env/globals.ion
@@ -1,0 +1,165 @@
+{
+    simple_1_col_1_group: [
+        {
+            col1: 1
+        },
+        {
+            col1: 1
+        }
+    ],
+    simple_2_col_1_group: [
+        {
+            col1: 1,
+            col2: 10
+        },
+        {
+            col1: 1,
+            col2: 10
+        }
+    ],
+    simple_1_col_2_groups: [
+        {
+            col1: 1
+        },
+        {
+            col1: 2
+        },
+        {
+            col1: 1
+        },
+        {
+            col1: 2
+        }
+    ],
+    simple_2_col_2_groups: [
+        {
+            col1: 1,
+            col2: 10
+        },
+        {
+            col1: 11,
+            col2: 110
+        },
+        {
+            col1: 1,
+            col2: 10
+        },
+        {
+            col1: 11,
+            col2: 110
+        }
+    ],
+    string_groups: [
+        {
+            col1: "a"
+        },
+        {
+            col1: "a"
+        }
+    ],
+    string_numbers: [
+        {
+            num: "1"
+        },
+        {
+            num: "2"
+        }
+    ],
+    products_sparse: [
+        {
+            productId: 1,
+            categoryId: 20,
+            regionId: 100,
+            supplierId_nulls: 10,
+            supplierId_missings: 10,
+            supplierId_mixed: 10,
+            price_nulls: 1.0,
+            price_missings: 1.0,
+            price_mixed: 1.0
+        },
+        {
+            productId: 2,
+            categoryId: 20,
+            regionId: 100,
+            supplierId_nulls: 10,
+            supplierId_missings: 10,
+            supplierId_mixed: 10,
+            price_nulls: 2.0,
+            price_missings: 2.0,
+            price_mixed: 2.0
+        },
+        {
+            productId: 3,
+            categoryId: 20,
+            regionId: 200,
+            supplierId_nulls: 10,
+            supplierId_missings: 10,
+            supplierId_mixed: 10,
+            price_nulls: 3.0,
+            price_missings: 3.0,
+            price_mixed: 3.0
+        },
+        {
+            productId: 5,
+            categoryId: 21,
+            regionId: 100,
+            supplierId_nulls: null,
+            price_nulls: null
+        },
+        {
+            productId: 4,
+            categoryId: 20,
+            regionId: 100,
+            supplierId_nulls: null,
+            supplierId_mixed: null,
+            price_nulls: null,
+            price_mixed: null
+        },
+        {
+            productId: 6,
+            categoryId: 21,
+            regionId: 100,
+            supplierId_nulls: 11,
+            supplierId_missings: 11,
+            supplierId_mixed: 11,
+            price_nulls: 4.0,
+            price_missings: 4.0,
+            price_mixed: 4.0
+        },
+        {
+            productId: 7,
+            categoryId: 21,
+            regionId: 200,
+            supplierId_nulls: 11,
+            supplierId_missings: 11,
+            supplierId_mixed: 11,
+            price_nulls: 5.0,
+            price_missings: 5.0,
+            price_mixed: 5.0
+        },
+        {
+            productId: 8,
+            categoryId: 21,
+            regionId: 200,
+            supplierId_nulls: null,
+            supplierId_mixed: null,
+            price_nulls: null,
+            price_mixed: null
+        },
+        {
+            productId: 9,
+            categoryId: 21,
+            regionId: 200,
+            supplierId_nulls: null,
+            price_nulls: null
+        },
+        {
+            productId: 10,
+            categoryId: 21,
+            regionId: 200,
+            supplierId_nulls: null,
+            supplierId_mixed: null,
+            price_nulls: null
+        }
+    ]
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,8 +19,21 @@ pub enum Commands {
         #[clap(value_parser)]
         query: String,
     },
-    /// interactive REPL (Read Eval Print Loop) shell
-    Repl,
+    /// Evaluate the query with the optional global environment
+    Eval {
+        /// Query to evaluate
+        #[clap(value_parser)]
+        query: String,
+        /// Optional environment file (.env or .ion)
+        #[clap(short = 'E', long = "environment")]
+        environment: Option<String>,
+    },
+    /// Interactive REPL (Read Eval Print Loop) shell
+    Repl {
+        /// Optional environment file (.env or .ion)
+        #[clap(short = 'E', long = "environment")]
+        environment: Option<String>,
+    },
 }
 
 #[derive(ArgEnum, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,0 +1,51 @@
+use crate::error::CLIErrors;
+use partiql_eval::env::basic::MapBindings;
+use partiql_eval::eval::Evaluated;
+use partiql_value::ion::parse_ion;
+use partiql_value::Value;
+use std::fs;
+use std::path::Path;
+
+pub fn evaluate(query: &str, globals: MapBindings<Value>) -> Result<Evaluated, CLIErrors> {
+    let parser = partiql_parser::Parser::default();
+    let parsed = parser.parse(query);
+    let lowered = partiql_logical_planner::lower(&parsed.expect("parse"));
+    let mut plan = partiql_eval::plan::EvaluatorPlanner.compile(&lowered);
+    plan.execute_mut(globals)
+        .map_err(|err| CLIErrors::from_eval_error(err, query))
+}
+
+pub fn get_bindings(environment: &Option<String>) -> Result<MapBindings<Value>, CLIErrors> {
+    let bindings = match environment {
+        None => MapBindings::default(),
+        Some(path) => {
+            let path = Path::new(path);
+            match path.extension() {
+                // TODO: can replace panics with an actual `CLIError`
+                None => panic!("Expected path"),
+                Some(extension) => match extension.to_str() {
+                    Some("env") => {
+                        let buf = fs::read_to_string(path)
+                            .map_err(|err| CLIErrors::from_io_error(err, ""))?;
+                        let env = evaluate(&buf, MapBindings::default())?.result;
+                        match env {
+                            Value::Tuple(t) => MapBindings::from(*t),
+                            _ => panic!("Expected a struct containing the input environment"),
+                        }
+                    }
+                    Some("ion") => {
+                        let buf = fs::read_to_string(path)
+                            .map_err(|err| CLIErrors::from_io_error(err, ""))?;
+                        let env = parse_ion(&buf);
+                        match env {
+                            Value::Tuple(t) => MapBindings::from(*t),
+                            _ => panic!("Expected a struct containing the input environment"),
+                        }
+                    }
+                    _ => panic!("Expected one of `.env` or `.ion`"),
+                },
+            }
+        }
+    };
+    Ok(bindings)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,7 @@ pub mod repl;
 
 #[cfg(feature = "visualize")]
 pub mod visualize;
+
+pub mod evaluate;
+pub mod parse;
+pub mod pretty;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,21 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 use clap::Parser;
-use partiql_cli::error::CLIErrors;
+use partiql_cli::args::Commands;
+use partiql_cli::evaluate::{evaluate, get_bindings};
+use partiql_cli::pretty::PrettyPrint;
 use partiql_cli::{args, repl};
-
-use partiql_parser::Parsed;
-
-#[allow(dead_code)]
-fn parse(query: &str) -> Result<Parsed, CLIErrors> {
-    partiql_parser::Parser::default()
-        .parse(query)
-        .map_err(CLIErrors::from_parser_error)
-}
 
 fn main() -> miette::Result<()> {
     let args = args::Args::parse();
 
     match &args.command {
-        args::Commands::Repl => repl::repl(),
+        args::Commands::Repl { environment } => repl::repl(environment),
 
         #[cfg(feature = "visualize")]
         args::Commands::Ast { format, query } => {
             use partiql_cli::args::Format;
+            use partiql_cli::parse::parse;
             use partiql_cli::visualize::render::{display, to_dot, to_json, to_png, to_svg};
             use std::io::Write;
 
@@ -38,6 +32,16 @@ fn main() -> miette::Result<()> {
                 Format::Display => display(&parsed.ast),
             }
 
+            Ok(())
+        }
+        Commands::Eval { query, environment } => {
+            let bindings = get_bindings(environment)?;
+            let evaluated = evaluate(query, bindings)?.result;
+            let mut pretty_evaluated = String::new();
+            evaluated
+                .pretty(&mut pretty_evaluated)
+                .expect("Error when trying to pretty print result");
+            println!("{pretty_evaluated}");
             Ok(())
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,8 @@
+use crate::error::CLIErrors;
+use partiql_parser::Parsed;
+
+pub fn parse(query: &str) -> Result<Parsed, CLIErrors> {
+    partiql_parser::Parser::default()
+        .parse(query)
+        .map_err(CLIErrors::from_parser_error)
+}

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,0 +1,69 @@
+use partiql_value::Value;
+
+use std::fmt::Result;
+use std::fmt::Write;
+
+// TODO: can move this to `partiql-value`?
+pub trait PrettyPrint {
+    fn pretty(&self, f: &mut String) -> Result;
+}
+
+impl PrettyPrint for Value {
+    fn pretty(&self, s: &mut String) -> Result {
+        pretty(self, s, 0)
+    }
+}
+
+fn pretty(value: &Value, s: &mut String, cur_indent_size: usize) -> Result {
+    // For now, defining an indent to be two spaces. We could allow users to pass in an indent string
+    // for more control.
+    let indent = "  ".repeat(cur_indent_size);
+    match value {
+        Value::List(l) => {
+            writeln!(s, "[")?;
+            let mut iter = l.iter().peekable();
+            while let Some(v) = iter.next() {
+                if iter.peek().is_some() {
+                    write!(s, "{indent}  ")?;
+                    pretty(v, s, cur_indent_size + 1)?;
+                    writeln!(s, ",")?;
+                } else {
+                    write!(s, "{indent}  ")?;
+                    pretty(v, s, cur_indent_size + 1)?;
+                }
+            }
+            write!(s, "\n{indent}]")
+        }
+        Value::Bag(b) => {
+            writeln!(s, "<<")?;
+            let mut iter = b.iter().peekable();
+            while let Some(v) = iter.next() {
+                if iter.peek().is_some() {
+                    write!(s, "{indent}  ")?;
+                    pretty(v, s, cur_indent_size + 1)?;
+                    writeln!(s, ",")?;
+                } else {
+                    write!(s, "{indent}  ")?;
+                    pretty(v, s, cur_indent_size + 1)?;
+                }
+            }
+            write!(s, "\n{indent}>>")
+        }
+        Value::Tuple(t) => {
+            writeln!(s, "{{")?;
+            let mut iter = t.pairs().peekable();
+            while let Some((k, v)) = iter.next() {
+                if iter.peek().is_some() {
+                    write!(s, "{indent}  {k}: ")?;
+                    pretty(v, s, cur_indent_size + 1)?;
+                    writeln!(s, ",")?;
+                } else {
+                    write!(s, "{indent}  {k}: ")?;
+                    pretty(v, s, cur_indent_size + 1)?;
+                }
+            }
+            write!(s, "\n{indent}}}")
+        }
+        _ => write!(s, "{value:?}"),
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -133,6 +133,7 @@ impl Validator for PartiqlHelper {
                 ";" => {
                     // TODO: there's a bug here where hitting enter from the middle of a query
                     //  containing a semi-colon will repeat the query
+                    //  https://github.com/partiql/partiql-rust-cli/issues/10
                     source = &source[..source_len - 1];
                 }
                 "\n" => {}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,6 +1,5 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use partiql_parser::ParseError;
 use rustyline::completion::Completer;
 use rustyline::config::Configurer;
 use rustyline::highlight::Highlighter;
@@ -9,7 +8,10 @@ use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{ColorMode, Context, Helper};
 use std::borrow::Cow;
+
 use std::fs::OpenOptions;
+use std::panic;
+use std::panic::AssertUnwindSafe;
 
 use std::path::Path;
 
@@ -20,8 +22,14 @@ use syntect::util::as_24_bit_terminal_escaped;
 
 use miette::{IntoDiagnostic, Report};
 use owo_colors::OwoColorize;
+use partiql_eval::env::basic::MapBindings;
+use partiql_eval::eval::Evaluated;
+
+use partiql_value::Value;
 
 use crate::error::CLIErrors;
+use crate::evaluate::get_bindings;
+use crate::pretty::PrettyPrint;
 
 static ION_SYNTAX: &str = include_str!("ion.sublime-syntax");
 static PARTIQL_SYNTAX: &str = include_str!("partiql.sublime-syntax");
@@ -47,10 +55,11 @@ struct PartiqlHelper {
     config: PartiqlHelperConfig,
     syntaxes: SyntaxSet,
     themes: ThemeSet,
+    globals: MapBindings<Value>,
 }
 
 impl PartiqlHelper {
-    pub fn new(config: PartiqlHelperConfig) -> Result<Self, ()> {
+    pub fn new(globals: MapBindings<Value>, config: PartiqlHelperConfig) -> Result<Self, ()> {
         let ion_def = SyntaxDefinition::load_from_str(ION_SYNTAX, false, Some("ion")).unwrap();
         let partiql_def =
             SyntaxDefinition::load_from_str(PARTIQL_SYNTAX, false, Some("partiql")).unwrap();
@@ -66,6 +75,7 @@ impl PartiqlHelper {
             config,
             syntaxes,
             themes,
+            globals,
         })
     }
 }
@@ -116,40 +126,68 @@ impl Validator for PartiqlHelper {
             source = &source[4..];
         }
 
+        let source_len = source.len();
+        match source_len {
+            0 => return Ok(ValidationResult::Valid(None)),
+            _ => match &source[source_len - 1..source_len] {
+                ";" => {
+                    // TODO: there's a bug here where hitting enter from the middle of a query
+                    //  containing a semi-colon will repeat the query
+                    source = &source[..source_len - 1];
+                }
+                "\n" => {}
+                _ => return Ok(ValidationResult::Incomplete),
+            },
+        }
+
         let parser = partiql_parser::Parser::default();
         let result = parser.parse(source);
+        let globals = self.globals.clone();
         match result {
-            Ok(_parsed) => {
+            Ok(parsed) => {
                 #[cfg(feature = "visualize")]
                 if flag_display {
                     use crate::visualize::render::display;
-                    display(&_parsed.ast);
+                    display(&parsed.ast);
                 }
-
-                Ok(ValidationResult::Valid(None))
+                // TODO: when better error-handling ergonomics are added to partiql-lang-rust
+                //  evaluation such as Result types rather than panics. Replace following code.
+                //  Tracking issue: https://github.com/partiql/partiql-lang-rust/issues/349
+                let evaluated = panic::catch_unwind(AssertUnwindSafe(|| {
+                    let lowered = partiql_logical_planner::lower(&parsed);
+                    let mut plan = partiql_eval::plan::EvaluatorPlanner.compile(&lowered);
+                    plan.execute_mut(globals)
+                }));
+                match evaluated {
+                    Ok(Ok(Evaluated { result: v })) => {
+                        let mut pretty_v = String::new();
+                        v.pretty(&mut pretty_v).expect("TODO: panic message");
+                        println!("\n==='\n{pretty_v}");
+                        Ok(ValidationResult::Valid(None))
+                    }
+                    Ok(Err(e)) => {
+                        let err = Report::new(CLIErrors::from_eval_error(e, source));
+                        Ok(ValidationResult::Invalid(Some(format!("\n\n{err:?}"))))
+                    }
+                    Err(panic_eval_error) => Ok(ValidationResult::Invalid(Some(format!(
+                        "\n\n{panic_eval_error:?}"
+                    )))),
+                }
             }
             Err(e) => {
-                if e.errors
-                    .iter()
-                    .any(|err| matches!(err, ParseError::UnexpectedEndOfInput))
-                {
-                    // TODO For now, this is what allows you to do things like hit `<ENTER>` and continue writing the query on the next line in the middle of a query.
-                    // TODO we should probably do something more ergonomic. Perhaps require a `;` or two newlines to end?
-                    Ok(ValidationResult::Incomplete)
-                } else {
-                    let err = Report::new(CLIErrors::from_parser_error(e));
-                    Ok(ValidationResult::Invalid(Some(format!("\n\n{:?}", err))))
-                }
+                let err = Report::new(CLIErrors::from_parser_error(e));
+                Ok(ValidationResult::Invalid(Some(format!("\n\n{err:?}"))))
             }
         }
     }
 }
 
-pub fn repl() -> miette::Result<()> {
+pub fn repl(environment: &Option<String>) -> miette::Result<()> {
+    let bindings = get_bindings(environment)?;
     let mut rl = rustyline::Editor::<PartiqlHelper>::new().into_diagnostic()?;
     rl.set_color_mode(ColorMode::Forced);
     rl.set_helper(Some(
-        PartiqlHelper::new(PartiqlHelperConfig::infer()).unwrap(),
+        PartiqlHelper::new(bindings, PartiqlHelperConfig::infer()).unwrap(),
     ));
     let expanded = shellexpand::tilde("~/partiql_cli.history").to_string();
     let history_path = Path::new(&expanded);
@@ -167,10 +205,10 @@ pub fn repl() -> miette::Result<()> {
     println!("===============================");
 
     loop {
-        let readline = rl.readline(">> ");
+        let readline = rl.readline("PartiQL> ");
         match readline {
             Ok(line) => {
-                println!("{}", "Parse OK!".green());
+                println!("\n---\n{}", "OK!".green());
                 rl.add_history_entry(line);
             }
             Err(_) => {


### PR DESCRIPTION
Adds eval support to the CLI and REPL. Also makes the following changes
- Upgrades to partiql Rust v0.3.* crates
- Adds a pretty-printer for PartiQL values
- [REPL] adds ability to double newline or use semicolon to denote end of query (should fix https://github.com/partiql/partiql-rust-cli/issues/8)
- Should fix build issues (should fix https://github.com/partiql/partiql-rust-cli/issues/1 and https://github.com/partiql/partiql-rust-cli/issues/4)
- Fixes some links following the move from `partiql-lang-rust` to its own repo
- Updates GH Action Rust toolchains to `dtolnay/rust-toolchain` (should fix #5)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
