### PR TITLE
Add feedback that a query is running, and time it took

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ supports-hyperlinks = "1.*"
 termbg = "0.4.*"
 shellexpand = "2.*"
 
+console = "0.15"
+indicatif = "0.17"
+dialoguer = "0.10"
 
 thiserror = "1.*"
 miette = { version ="5.*", features = ["fancy"] }


### PR DESCRIPTION
Adds a spinner to show that a query is running, as well as finish & abandon messages.

--

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
