### PR TITLE
Add table formatting; Add formatting commands to REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ console = "0.15"
 indicatif = "0.17"
 dialoguer = "0.10"
 
+comfy-table = "6"
+
 thiserror = "1.*"
 miette = { version ="5.*", features = ["fancy"] }
 clap = { version = "3.*", features = ["derive"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -47,6 +47,8 @@ pub enum OutputFormat {
     IonLines,
     /// Ion Text, pretty printed
     IonPretty,
+    /// Table
+    Table,
 }
 
 #[derive(ArgEnum, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,0 +1,124 @@
+use crate::args::OutputFormat;
+use crate::pretty::PrettyPrint;
+
+use comfy_table::{Cell, Color, Table};
+use ion_rs::IonWriter;
+use partiql_extension_ion::encode::{IonEncoderBuilder, IonEncoderConfig};
+use partiql_extension_ion::Encoding;
+use partiql_value::Value;
+use std::collections::HashMap;
+use std::io::Write;
+
+pub fn print_value(format: &OutputFormat, value: &Value) {
+    match format {
+        OutputFormat::Partiql => {
+            partiql_pretty_print(value);
+        }
+        OutputFormat::IonLines => {
+            let mut out = std::io::stdout().lock();
+            let mut writer = ion_rs::TextWriterBuilder::lines()
+                .build(&mut out)
+                .expect("ion writer");
+            ion_encode(&mut writer, value);
+        }
+        OutputFormat::IonPretty => {
+            let mut out = std::io::stdout().lock();
+            let mut writer = ion_rs::TextWriterBuilder::pretty()
+                .build(&mut out)
+                .expect("ion writer");
+            ion_encode(&mut writer, value);
+        }
+        OutputFormat::Table => {
+            // TODO: this should really be based on static analysis of the query's returned 'columns'
+            let mut columns = vec![];
+            let mut columns_to_id = HashMap::new();
+            for v in value.iter() {
+                if let Value::Tuple(t) = v {
+                    for (k, _v) in t.pairs() {
+                        columns_to_id.entry(k).or_insert_with(|| {
+                            columns.push(k);
+
+                            columns.len() - 1
+                        });
+                    }
+                }
+            }
+            let empty_row: Vec<_> = std::iter::repeat(Value::Null)
+                .take(columns.len())
+                .map(|v| Cell::new(partiql_pretty(&v)).fg(Color::DarkRed))
+                .collect();
+
+            if columns.is_empty() {
+                let mut table = Table::new();
+                table.set_header(vec!["Value"]);
+                for v in value.iter() {
+                    table.add_row(&[partiql_table_pretty(v)]);
+                }
+
+                println!("{table}");
+            } else {
+                let mut table = Table::new();
+                table.set_header(columns);
+                for v in value.iter() {
+                    let mut row = empty_row.clone();
+                    for (k, v) in v.as_tuple_ref().as_ref().pairs() {
+                        match columns_to_id.get(&k) {
+                            None => {
+                                todo!("error mapping key to column")
+                            }
+                            Some(idx) => {
+                                //
+                                let col = Cell::new(partiql_table_pretty(v));
+                                let col = match v {
+                                    // Color Null & Missing red
+                                    Value::Null | Value::Missing => col.fg(Color::DarkRed),
+                                    _ => col,
+                                };
+                                row[*idx] = col
+                            }
+                        }
+                    }
+                    table.add_row(row);
+                }
+
+                println!("{table}");
+            }
+        }
+    }
+}
+
+fn partiql_table_pretty(value: &Value) -> String {
+    let pretty = partiql_pretty(value);
+    if pretty.starts_with('\'') && pretty.ends_with('\'') {
+        pretty.trim_matches('\'').to_string()
+    } else {
+        pretty
+    }
+}
+
+fn partiql_pretty(value: &Value) -> String {
+    let mut pretty = String::new();
+    value
+        .pretty(&mut pretty)
+        .expect("Error when trying to pretty print result");
+    pretty
+}
+
+fn partiql_pretty_print(value: &Value) {
+    let pretty = partiql_pretty(value);
+    println!("{pretty}");
+}
+
+fn ion_encode<'a, W, I>(writer: &'a mut I, value: &Value)
+where
+    W: Write + 'a,
+    I: IonWriter<Output = W> + 'a,
+{
+    let mut encoder = IonEncoderBuilder::new(IonEncoderConfig::default().with_mode(Encoding::Ion))
+        .build(writer)
+        .expect("ion encoder build");
+
+    value
+        .iter()
+        .for_each(|v| encoder.write_value(v).expect("ion encoder write"));
+}

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -67,7 +67,6 @@ pub fn print_value(format: &OutputFormat, value: &Value) {
                                 todo!("error mapping key to column")
                             }
                             Some(idx) => {
-                                //
                                 let col = Cell::new(partiql_table_pretty(v));
                                 let col = match v {
                                     // Color Null & Missing red

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod repl;
 pub mod visualize;
 
 pub mod evaluate;
+pub mod formatting;
 pub mod parse;
 pub mod pretty;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,10 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 use clap::Parser;
-use ion_rs::IonWriter;
-use partiql_cli::args::{Commands, OutputFormat};
-use partiql_cli::evaluate::{evaluate, get_bindings};
-use partiql_cli::pretty::PrettyPrint;
+use partiql_cli::args::Commands;
+use partiql_cli::evaluate::{evaluate_parsed, get_bindings};
+use partiql_cli::formatting::print_value;
 use partiql_cli::{args, repl};
-use partiql_extension_ion::encode::{IonEncoderBuilder, IonEncoderConfig};
-use partiql_extension_ion::Encoding;
-use partiql_value::Value;
-use std::io::Write;
 
 fn main() -> miette::Result<()> {
     let args = args::Args::parse();
@@ -45,50 +40,11 @@ fn main() -> miette::Result<()> {
             environment,
         } => {
             let bindings = get_bindings(environment)?;
-            let evaluated = evaluate(query, bindings)?.result;
-            match output {
-                OutputFormat::Partiql => {
-                    partiql_pretty_print(evaluated);
-                }
-                OutputFormat::IonLines => {
-                    let mut out = std::io::stdout().lock();
-                    let mut writer = ion_rs::TextWriterBuilder::lines()
-                        .build(&mut out)
-                        .expect("ion writer");
-                    ion_encode(&mut writer, evaluated);
-                }
-                OutputFormat::IonPretty => {
-                    let mut out = std::io::stdout().lock();
-                    let mut writer = ion_rs::TextWriterBuilder::pretty()
-                        .build(&mut out)
-                        .expect("ion writer");
-                    ion_encode(&mut writer, evaluated);
-                }
-            }
-
+            let parser = partiql_parser::Parser::default();
+            let parsed = parser.parse(query).expect("parse");
+            let evaluated = evaluate_parsed(&parsed, bindings)?.result;
+            print_value(output, &evaluated);
             Ok(())
         }
     }
-}
-
-fn partiql_pretty_print(value: Value) {
-    let mut pretty = String::new();
-    value
-        .pretty(&mut pretty)
-        .expect("Error when trying to pretty print result");
-    println!("{pretty}");
-}
-
-fn ion_encode<'a, W, I>(writer: &'a mut I, value: Value)
-where
-    W: Write + 'a,
-    I: IonWriter<Output = W> + 'a,
-{
-    let mut encoder = IonEncoderBuilder::new(IonEncoderConfig::default().with_mode(Encoding::Ion))
-        .build(writer)
-        .expect("ion encoder build");
-
-    value
-        .iter()
-        .for_each(|v| encoder.write_value(v).expect("ion encoder write"));
 }


### PR DESCRIPTION
Adds 
- support for `-f table` to eval command to format output as a table
- support for `\table` as prefix to query in repl to format output as a table
- support for `\ion-lines` as prefix to query in repl to format output as a ion, one top-level value per line
- support for `\ion-pretty` as prefix to query in repl to format output as a pretty-printed ion text
- support for `\partiql` (default if no `\<format>` provided as prefix to query in repl to format output as a partiql

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
