### PR TITLE
Create cache dir

### DIFF
--- a/src/repl/config.rs
+++ b/src/repl/config.rs
@@ -29,6 +29,7 @@ pub(crate) fn repl_config() -> ReplConfig {
     let config_dir = dirs.config_dir();
     let cache_dir = dirs.cache_dir();
     std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
 
     let mut conf = config_dir.to_path_buf();
     conf.push("partiql-cli.toml");


### PR DESCRIPTION
The Rust CLI wouldn't create the cache directory previously. This led to the following error when trying to load the command history:

```
❯ ./target/debug/partiql-cli repl
thread 'main' panicked at 'history load: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })', src/repl/repl.rs:246:36
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
