### PR TITLE
Add rendering of plan to dot graphs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 edition = "2021"
 version = "0.4.0"
 
-# Example of customizing binaries in Cargo.toml.
+
 [[bin]]
 name = "partiql-cli"
 test = false
@@ -25,17 +25,18 @@ bench = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# Currently relies on some unreleased features; waiting on partiql v0.5
 [dependencies]
-partiql-parser = { features=["serde"], version = "0.4" }
-partiql-catalog = "0.4"
-partiql-source-map = "0.4"
-partiql-ast = "0.4"
-partiql-logical-planner ="0.4"
-partiql-logical = "0.4"
-partiql-value = "0.4"
-partiql-eval = "0.4"
-partiql-extension-ion = "0.4"
-partiql-extension-ion-functions = "~0.4.1"
+partiql-parser = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-catalog = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-source-map = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-ast = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-logical-planner = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-logical = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-value = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-eval = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-extension-ion =  { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-extension-ion-functions = { git="https://github.com/partiql/partiql-lang-rust" }
 
 once_cell = "1"
 
@@ -47,6 +48,8 @@ supports-unicode = "1.*"
 supports-hyperlinks = "1.*"
 termbg = "0.4.*"
 shellexpand = "2.*"
+
+itertools = "0.10"
 
 console = "0.15"
 indicatif = "0.17"
@@ -61,7 +64,7 @@ thiserror = "1.*"
 miette = { version ="5.*", features = ["fancy"] }
 clap = { version = "3.*", features = ["derive"] }
 
-uuid = {verison="1.3", features=["v4"]}
+uuid = {version="1.3", features=["v4"]}
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
@@ -86,6 +89,7 @@ ion-rs = {git="https://github.com/amazon-ion/ion-rust"}
 [patch.crates-io]
 ion-rs= {git="https://github.com/amazon-ion/ion-rust"}
 
+
 [features]
 default = []
 serde = [
@@ -94,6 +98,8 @@ serde = [
   "partiql-parser/serde",
   "partiql-source-map/serde",
   "partiql-ast/serde",
+  "partiql-logical/serde",
+  "partiql-value/serde",
 ]
 visualize = [
   "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,17 @@ bench = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-# Currently relies on some unreleased features; waiting on partiql v0.5
 [dependencies]
-partiql-parser = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-catalog = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-source-map = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-ast = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-logical-planner = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-logical = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-value = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-eval = { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-extension-ion =  { git="https://github.com/partiql/partiql-lang-rust" }
-partiql-extension-ion-functions = { git="https://github.com/partiql/partiql-lang-rust" }
+partiql-parser = "0.5"
+partiql-catalog = "0.5"
+partiql-source-map = "0.5"
+partiql-ast = "0.5"
+partiql-logical-planner = "0.5"
+partiql-logical = "0.5"
+partiql-value = "0.5"
+partiql-eval = "0.5"
+partiql-extension-ion =  "0.5"
+partiql-extension-ion-functions = "0.5"
 
 once_cell = "1"
 
@@ -83,11 +82,7 @@ tiny-skia = { version ="0.6.*", optional = true }
 strum = { version ="0.24.*", features = ["derive"], optional = true }
 dot-writer = { version = "0.1.*", optional = true }
 
-ion-rs = {git="https://github.com/amazon-ion/ion-rust"}
-
-
-[patch.crates-io]
-ion-rs= {git="https://github.com/amazon-ion/ion-rust"}
+ion-rs = "0.17"
 
 
 [features]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Features:
 
 # Visualizations
 In order to use any of the [Graphviz][Graphviz]-based visualizations, you will need the graphviz libraries
-installed on your machine (e.g. `brew install graphviz` or similar).
+installed on your machine (e.g. `brew install graphviz` or similar). You will also need to build with the
+`visualize` [feature][CargoFeatures] enabled.
 
 # TODO
 
@@ -53,3 +54,4 @@ See [REPL-tagged issues](https://github.com/partiql/partiql-rust-cli/issues?q=is
 
 [Graphviz]: https://graphviz.org/
 [GvDot]: https://graphviz.org/doc/info/lang.html
+[CargoFeatures]: https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,6 +19,16 @@ pub enum Commands {
         #[clap(value_parser)]
         query: String,
     },
+    #[cfg(feature = "visualize")]
+    /// Dump the Plan for a query
+    Plan {
+        #[clap(short = 'T', long = "format", value_enum)]
+        format: Format,
+
+        /// Query to parse
+        #[clap(value_parser)]
+        query: String,
+    },
     /// Evaluate the query with the optional global environment
     Eval {
         /// Query to evaluate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,4 @@ pub mod visualize;
 
 pub mod evaluate;
 pub mod formatting;
-pub mod parse;
 pub mod pretty;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,0 @@
-use crate::error::CLIErrors;
-use partiql_parser::Parsed;
-
-pub fn parse(query: &str) -> Result<Parsed, CLIErrors> {
-    partiql_parser::Parser::default()
-        .parse(query)
-        .map_err(CLIErrors::from)
-}

--- a/src/visualize/ast_to_dot.rs
+++ b/src/visualize/ast_to_dot.rs
@@ -1,5 +1,6 @@
 use partiql_ast::ast;
 
+use crate::visualize::common::{ToDotGraph, BG_COLOR, FG_COLOR};
 use dot_writer::{Attributes, DotWriter, Node, NodeId, Scope, Shape};
 
 /*
@@ -57,10 +58,6 @@ impl ChildEdgeExt for Targets {
 
 type Targets = Vec<NodeId>;
 
-pub trait ToDotGraph<T> {
-    fn to_graph(self, ast: &T) -> String;
-}
-
 pub struct AstToDot {}
 
 impl Default for AstToDot {
@@ -68,9 +65,6 @@ impl Default for AstToDot {
         AstToDot {}
     }
 }
-
-const BG_COLOR: &'static str = "\"#002b3600\"";
-const FG_COLOR: &'static str = "\"#839496\"";
 
 impl<T> ToDotGraph<T> for AstToDot
 where
@@ -203,10 +197,9 @@ fn lit_to_str(ast: &ast::Lit) -> String {
         Lit::NationalCharStringLit(l) => format!("'{}'", l),
         Lit::BitStringLit(l) => format!("b'{}'", l),
         Lit::HexStringLit(l) => format!("x'{}'", l),
-        Lit::CollectionLit(l) => match l {
-            ast::CollectionLit::ArrayLit(al) => format!("[{}]", al),
-            ast::CollectionLit::BagLit(bl) => format!("<<{}>>", bl),
-        },
+        Lit::BagLit(b) => todo!("bag literals"),
+        Lit::ListLit(b) => todo!("list literals"),
+        Lit::StructLit(b) => todo!("struct literals"),
         Lit::TypedLit(val_str, ty) => {
             format!("{} '{}'", type_to_str(ty), val_str)
         }

--- a/src/visualize/common.rs
+++ b/src/visualize/common.rs
@@ -1,0 +1,6 @@
+pub(crate) trait ToDotGraph<T> {
+    fn to_graph(self, data: &T) -> String;
+}
+
+pub(crate) const BG_COLOR: &'static str = "\"#002b3600\"";
+pub(crate) const FG_COLOR: &'static str = "\"#839496\"";

--- a/src/visualize/mod.rs
+++ b/src/visualize/mod.rs
@@ -1,2 +1,4 @@
 pub mod ast_to_dot;
+pub(crate) mod common;
+pub mod plan_to_dot;
 pub mod render;

--- a/src/visualize/plan_to_dot.rs
+++ b/src/visualize/plan_to_dot.rs
@@ -1,0 +1,213 @@
+use dot_writer::{Attributes, DotWriter, Node, NodeId, Scope, Shape};
+use std::collections::HashMap;
+
+use crate::visualize::common::{ToDotGraph, BG_COLOR, FG_COLOR};
+use crate::visualize::render::to_dot;
+use itertools::Itertools;
+use partiql_logical::{
+    AggregateExpression, BinaryOp, BindingsOp, JoinKind, LogicalPlan, OpId, ValueExpr,
+};
+use serde::de::Unexpected::Option;
+
+pub struct PlanToDot {}
+
+impl Default for PlanToDot {
+    fn default() -> Self {
+        PlanToDot {}
+    }
+}
+
+impl PlanToDot {
+    pub(crate) fn to_dot(&self, scope: &mut Scope, plan: &LogicalPlan<BindingsOp>) {
+        let mut graph_nodes = HashMap::new();
+        for (opid, op) in plan.operators_by_id() {
+            graph_nodes.insert(opid, self.op_to_dot(scope, op));
+        }
+
+        for (src, dst, branch) in plan.flows() {
+            let src = graph_nodes.get(src).expect("src op");
+            let dst = graph_nodes.get(dst).expect("dst op");
+
+            scope
+                .edge(src, dst)
+                .attributes()
+                .set_label(&branch.to_string());
+        }
+    }
+
+    fn op_to_dot(&self, scope: &mut Scope, op: &BindingsOp) -> NodeId {
+        let mut node = scope.node_auto();
+        let label = match op {
+            BindingsOp::Scan(s) => {
+                format!("{{scan | {} | as {} }}", expr_to_str(&s.expr), s.as_key)
+            }
+            BindingsOp::Pivot(p) => format!(
+                "{{pivot | {} | at {} }}",
+                expr_to_str(&p.value),
+                expr_to_str(&p.key)
+            ),
+            BindingsOp::Unpivot(u) => format!(
+                "{{unpivot | {}  | as {} | at {} }}",
+                expr_to_str(&u.expr),
+                &u.as_key,
+                &u.at_key.as_deref().unwrap_or("")
+            ),
+            BindingsOp::Filter(f) => format!("{{filter | {} }}", expr_to_str(&f.expr)),
+            BindingsOp::OrderBy(o) => {
+                let specs = o
+                    .specs
+                    .iter()
+                    .map(|s| {
+                        format!(
+                            "{} {:?} NULLS {:?}",
+                            expr_to_str(&s.expr),
+                            s.order,
+                            s.null_order
+                        )
+                    })
+                    .join(" | ");
+                format!("{{order by | {} }}", specs)
+            }
+            BindingsOp::LimitOffset(lo) => {
+                let clauses = [
+                    lo.limit
+                        .as_ref()
+                        .map(|e| format!("limit {}", expr_to_str(&e))),
+                    lo.offset
+                        .as_ref()
+                        .map(|e| format!("offset {}", expr_to_str(&e))),
+                ]
+                .iter()
+                .filter_map(|o| o.as_ref())
+                .join(" | ");
+                format!("{{ {clauses} }}")
+            }
+            BindingsOp::Join(join) => {
+                let kind = match join.kind {
+                    JoinKind::Inner => "inner",
+                    JoinKind::Left => "left",
+                    JoinKind::Right => "right",
+                    JoinKind::Full => "full",
+                    JoinKind::Cross => "cross",
+                };
+                format!(
+                    "{{ {} join | {} }}",
+                    kind,
+                    join.on
+                        .as_ref()
+                        .map(|e| expr_to_str(e))
+                        .unwrap_or("".to_string())
+                )
+            }
+            BindingsOp::SetOp => "set op (TODO)".to_string(),
+            BindingsOp::Project(p) => {
+                format!(
+                    "{{project  | {} }}",
+                    p.exprs
+                        .iter()
+                        .map(|(k, e)| format!("{}:{}", k, expr_to_str(e)))
+                        .join(" | "),
+                )
+            }
+            BindingsOp::ProjectAll => {
+                format!("{{project  * }}")
+            }
+            BindingsOp::ProjectValue(pv) => {
+                format!("{{project value | {} }}", expr_to_str(&pv.expr))
+            }
+            BindingsOp::ExprQuery(eq) => {
+                format!("{{ {} }}", expr_to_str(&eq.expr))
+            }
+            BindingsOp::Distinct => "distinct".to_string(),
+            BindingsOp::GroupBy(g) => {
+                format!(
+                    "{{group by | {:?} | {{ keys | {{ {} }} }} | {{ aggs | {{ {} }} }} | as {} }}",
+                    g.strategy,
+                    g.exprs
+                        .iter()
+                        .map(|(k, e)| format!("{}:{}", k, expr_to_str(e)))
+                        .join(" | "),
+                    g.aggregate_exprs.iter().map(agg_expr_to_str).join(" | "),
+                    g.group_as_alias.as_deref().unwrap_or(""),
+                )
+            }
+            BindingsOp::Having(h) => {
+                format!("{{ having | {} }}", expr_to_str(&h.expr))
+            }
+            BindingsOp::Sink => "sink".to_string(),
+        };
+        node.set_shape(Shape::Mrecord)
+            .set_label(&format!("{label}"));
+
+        node.id()
+    }
+}
+
+fn expr_to_str(expr: &ValueExpr) -> String {
+    match expr {
+        ValueExpr::BinaryExpr(BinaryOp::And, lhs, rhs) => {
+            format!(
+                "{{  AND | {{ {} | {} }}  }}",
+                expr_to_str(lhs),
+                expr_to_str(rhs)
+            )
+        }
+        ValueExpr::BinaryExpr(BinaryOp::Or, lhs, rhs) => {
+            format!(
+                "{{  OR | {{ {} | {} }}  }}",
+                expr_to_str(lhs),
+                expr_to_str(rhs)
+            )
+        }
+        expr => {
+            let expr: String = format!("{:?}", expr).escape_default().collect();
+            let expr = expr.replace('{', "\\{");
+            let expr = expr.replace('}', "\\}");
+            let expr = expr.replace('<', "\\<");
+            let expr = expr.replace('>', "\\>");
+            expr
+        }
+    }
+}
+
+fn agg_expr_to_str(agg_expr: &AggregateExpression) -> String {
+    let expr: String = format!("{:?}", agg_expr.expr).escape_default().collect();
+    let expr = expr.replace('{', "\\{");
+    let expr = expr.replace('}', "\\}");
+    format!(
+        "{}:{}:{:?}:{:?}",
+        agg_expr.name, expr, agg_expr.func, agg_expr.setq
+    )
+}
+
+impl ToDotGraph<LogicalPlan<BindingsOp>> for PlanToDot {
+    fn to_graph(mut self, plan: &LogicalPlan<BindingsOp>) -> String {
+        let mut output_bytes = Vec::new();
+
+        {
+            let mut writer = DotWriter::from(&mut output_bytes);
+            writer.set_pretty_print(true);
+            let mut digraph = writer.digraph();
+            digraph
+                .graph_attributes()
+                .set_rank_direction(dot_writer::RankDirection::TopBottom)
+                .set("bgcolor", BG_COLOR, false)
+                .set("fontcolor", FG_COLOR, false)
+                .set("pencolor", FG_COLOR, false);
+            digraph.node_attributes().set("color", FG_COLOR, false).set(
+                "fontcolor",
+                FG_COLOR,
+                false,
+            );
+            digraph.edge_attributes().set("color", FG_COLOR, false).set(
+                "fontcolor",
+                FG_COLOR,
+                false,
+            );
+
+            self.to_dot(&mut digraph, plan);
+        }
+
+        return String::from_utf8(output_bytes).expect("invalid utf8");
+    }
+}


### PR DESCRIPTION
Draft PR until the below PRs have been released.

Relies on
- https://github.com/partiql/partiql-lang-rust/pull/380
- https://github.com/partiql/partiql-lang-rust/pull/382
- https://github.com/partiql/partiql-lang-rust/pull/385

Allows :

```shell
partiql-cli plan -T png "select t/10 AS foo from <<{'t': 100}, {'t': 200}>> AS data ORDER BY foo DESC" > plan_simple.png
```

To produce:
![plan_simple](https://github.com/partiql/partiql-rust-cli/assets/36067/2793feaf-4ebd-4286-85df-8ba71ab8b1c4)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
