### PR TITLE
Bump PartiQL libs version from 0.7 to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "PartiQL CLI"
 homepage = "https://github.com/partiql/partiql-rust-cli"
 repository = "https://github.com/partiql/partiql-rust-cli"
 license = "Apache-2.0"
-readme = "../README.md"
+readme = "README.md"
 keywords = ["sql", "parser", "query", "compilers", "cli"]
 categories = ["database", "compilers", "parser-implementations"]
 exclude = [
@@ -15,7 +15,7 @@ exclude = [
     "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.7.0"
+version = "0.11.0"
 
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,17 +26,17 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-partiql-parser = "0.7"
-partiql-catalog = "0.7"
-partiql-source-map = "0.7"
-partiql-ast = "0.7"
-partiql-ast-passes = "0.7"
-partiql-logical-planner = "0.7"
-partiql-logical = "0.7"
-partiql-value = "0.7"
-partiql-eval = "0.7"
-partiql-extension-ion = "0.7"
-partiql-extension-ion-functions = "0.7"
+partiql-parser = "0.11"
+partiql-catalog = "0.11"
+partiql-common = "0.11"
+partiql-ast = "0.11"
+partiql-ast-passes = "0.11"
+partiql-logical-planner = "0.11"
+partiql-logical = "0.11"
+partiql-value = "0.11"
+partiql-eval = "0.11"
+partiql-extension-ion = "0.11"
+partiql-extension-ion-functions = "0.11"
 
 once_cell = "1"
 
@@ -94,7 +94,7 @@ serde = [
     "dep:serde",
     "dep:serde_json",
     "partiql-parser/serde",
-    "partiql-source-map/serde",
+    "partiql-common/serde",
     "partiql-ast/serde",
     "partiql-logical/serde",
     "partiql-value/serde",

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use miette::{Diagnostic, LabeledSpan, SourceCode};
 use partiql_ast_passes::error::{AstTransformError, AstTransformationError};
 use partiql_eval::error::{EvalErr, EvaluationError, PlanErr, PlanningError};
 use partiql_parser::{ParseError, ParserError};
-use partiql_source_map::location::{ByteOffset, BytePosition, Location};
+use partiql_common::syntax::location::{ByteOffset, BytePosition, Location, Located};
 use std::io::Error;
 
 use thiserror::Error;
@@ -130,14 +130,14 @@ impl From<std::io::Error> for CLIError {
 impl<'a> From<(&str, ParseError<'a>)> for CLIError {
     fn from((source, err): (&str, ParseError<'a>)) -> Self {
         match err {
-            ParseError::SyntaxError(partiql_source_map::location::Located { inner, location }) => {
+            ParseError::SyntaxError(Located { inner, location }) => {
                 CLIError::SyntaxError {
                     src: source.to_string(),
                     msg: format!("Syntax error `{inner}`"),
                     loc: location,
                 }
             }
-            ParseError::UnexpectedToken(partiql_source_map::location::Located {
+            ParseError::UnexpectedToken(Located {
                 inner,
                 location,
             }) => CLIError::SyntaxError {
@@ -145,7 +145,7 @@ impl<'a> From<(&str, ParseError<'a>)> for CLIError {
                 msg: format!("Unexpected token `{}`", inner.token),
                 loc: location,
             },
-            ParseError::LexicalError(partiql_source_map::location::Located { inner, location }) => {
+            ParseError::LexicalError(Located { inner, location }) => {
                 CLIError::SyntaxError {
                     src: source.to_string(),
                     msg: format!("Lexical error `{inner}`"),

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,6 +1,7 @@
 use crate::error::{CLIError, CLIErrors};
 
-use partiql_catalog::{Extension, PartiqlCatalog};
+use partiql_catalog::extension::Extension;
+use partiql_catalog::catalog::PartiqlCatalog;
 use partiql_eval::env::basic::MapBindings;
 use partiql_eval::eval::{BasicContext, EvalPlan, Evaluated};
 use partiql_eval::plan::EvaluationMode;


### PR DESCRIPTION
*Issue #, if available:*
No issue

*Description of changes:*
- Bump all PartiQL lib version from `0.7` to `0.11`
- Remove `partiql-source-map` in favor of `partiql-common`
  - Update imports to use `partiql-common` instead of `partiql-source-map`.
- Bump version to `0.11.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
